### PR TITLE
Fix PDF Slide DOIs

### DIFF
--- a/submissions/427/index.qmd
+++ b/submissions/427/index.qmd
@@ -27,16 +27,16 @@ key-points:
   - Developing an XML schema for a scholarly edition project is challenging but can provide a solid foundation for the project when executed effectively.
 date: 09-13-2024
 date-modified: 11-15-2024
-doi: 10.5281/zenodo.14171339
+doi: 10.5281/zenodo.14851557
 other-links:
   - text: Presentation Slides (PDF)
-    href: https://doi.org/10.5281/zenodo.14171339
+    href: https://doi.org/10.5281/zenodo.14851557
 bibliography: references.bib
 ---
 
 ::: {.callout-note appearance="simple" icon=false}
 
-For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14171339/files/427_DigiHistCH24_SolidGround_Slides.pdf).
+For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14851557/files/427_DigiHistCH24_SolidGround_Slides.pdf).
 
 :::
 

--- a/submissions/444/index.qmd
+++ b/submissions/444/index.qmd
@@ -26,16 +26,16 @@ key-points:
   - Key point 3 The user test survey of the portal with 19th-century letter metadata showed that building a committed test group is challenging and that 'traditional' humanists have difficulties in studying mass data.
 date: 09-12-2024
 date-modified: 11-15-2024
-doi: 10.5281/zenodo.14171306
+doi: 10.5281/zenodo.14851507
 other-links:
   - text: Presentation Slides (PDF)
-    href: https://doi.org/10.5281/zenodo.14171306
+    href: https://doi.org/10.5281/zenodo.14851507
 bibliography: references.bib
 ---
 
 ::: {.callout-note appearance="simple" icon=false}
 
-For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14171306/files/444_DigiHistCH24_LetterMetadata_Slides.pdf).
+For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14851507/files/444_DigiHistCH24_LetterMetadata_Slides.pdf).
 
 :::
 

--- a/submissions/445/index.qmd
+++ b/submissions/445/index.qmd
@@ -24,16 +24,16 @@ key-points:
   - Working with historical documents today often takes place at the intersection between tried and tested analog methods and new digital approaches, which is why our teaching module takes these intersections into account.
 date: 09-12-2024
 date-modified: 11-15-2024
-doi: 10.5281/zenodo.14171285
+doi: 10.5281/zenodo.14851523
 other-links:
   - text: Presentation Slides (PDF)
-    href: https://doi.org/10.5281/zenodo.14171285
+    href: https://doi.org/10.5281/zenodo.14851523
 bibliography: references.bib
 ---
 
 ::: {.callout-note appearance="simple" icon=false}
 
-For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14171285/files/445_DigiHistCH24_AdFontes_Slides.pdf).
+For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14851523/files/445_DigiHistCH24_AdFontes_Slides.pdf).
 
 :::
 

--- a/submissions/482/index.qmd
+++ b/submissions/482/index.qmd
@@ -23,16 +23,16 @@ abstract: |
   Our presentation reflects on the experience gained in an ongoing SNSF-funded research project investigating the internationalization of patent systems. In our research, we mix different methods: traditional historical methods allow us to shed light on the role of intergovernmental agreements and of private networks of patent specialists; digital analysis enables us to trace how internationalization stemmed from patent practice itself, and to study the activity of patentees that have left few historical traces. Relying on a large corpus (over 4 million documents) of digitized patents, we use text mining and computer vision techniques to explore the corpus and operationalize the concept of internationalization. In this paper, we focus on the challenges of matching (almost) identical drawings between patents of different countries, combining image embeddings (obtained by using a pretrained convolutional neural network) and feature matching (SIFT).
 date: 09-12-2024
 date-modified: 11-15-2024
-doi: 10.5281/zenodo.14171307
+doi: 10.5281/zenodo.14851527
 other-links:
   - text: Presentation Slides (PDF)
-    href: https://doi.org/10.5281/zenodo.14171307
+    href: https://doi.org/10.5281/zenodo.14851527
 bibliography: references.bib
 ---
 
 ::: {.callout-note appearance="simple" icon=false}
 
-For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14171307/files/482_DigiHistCH_Internationalization_Slides.pdf).
+For this paper, slides are available [on Zenodo (PDF)](https://zenodo.org/records/14851527/files/482_DigiHistCH24_Internationalization_Slides.pdf).
 
 :::
 


### PR DESCRIPTION
# Pull request

## Proposed changes

Fixes #90 by creating new versions of the four items (427, 444, 445, 482) with faulty hyperlinks to the presentation slides on Zenodo.

After merging, I will upload the new PDFs to Zenodo.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[README](./README.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have mentioned all co-authors in the PR description as `Co-authored-by: Name <email@domain.com>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated DOIs and corresponding presentation slide links across several documents, ensuring that users are directed to the most current external resources without any changes to the overall content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->